### PR TITLE
Add sonatype as SBOM generator

### DIFF
--- a/internal/checks/build-pipelines/pipeline-integrity/rules.rego
+++ b/internal/checks/build-pipelines/pipeline-integrity/rules.rego
@@ -22,6 +22,7 @@ sbom_generation_commands = [
 	`syft .*`,
 	`spdx-sbom-generator`,
 	`cyclonedx-\w+`,
+        `jake sbom`,
 ]
 
 does_job_contain_one_of_tasks(job, regexes) {


### PR DESCRIPTION
## Description
sonatype has an SBOM generation tool called "jake", it should be one of the SBOM tools.

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/chain-bench/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/chain-bench/blob/main/CONTRIBUTING.md#pull-requests) in the PR title.
- [x] I've updated the [readme](https://github.com/aquasecurity/chain-bench/blob/main/README.md) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
