### PR TITLE
Add identifiers to the report metadata section

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alexeyco/simpletable v1.0.0
 	github.com/argonsecurity/pipeline-parser v0.1.12
 	github.com/google/go-github/v41 v41.0.0
+	github.com/google/uuid v1.2.0
 	github.com/imdario/mergo v0.3.12
 	github.com/migueleliasweb/go-github-mock v0.0.8
 	github.com/rs/zerolog v1.26.1

--- a/go.sum
+++ b/go.sum
@@ -536,6 +536,7 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -30,7 +30,7 @@ func NewScanCommand() *cobra.Command {
 			checks := checks.GetChecks(assetsData)
 			results, errors := checker.RunChecks(assetsData, chainbenchConfig, checks)
 
-			printer.PrintFindings(results, outputFilePath, isQuiet)
+			printer.PrintFindings(results, outputFilePath, isQuiet, repositoryUrl)
 			printer.PrintErrors(errors)
 			elapsed := time.Since(start)
 			logger.Infof("Scan completed: %s", elapsed.Round(time.Millisecond))

--- a/internal/printer/helpers.go
+++ b/internal/printer/helpers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aquasecurity/chain-bench/internal/models/checkmodels"
+	"github.com/google/uuid"
 )
 
 var (
@@ -28,7 +29,9 @@ type reportResult struct {
 
 type reportMetadata struct {
 	Date       string     `json:"date"`
+	ScanID     uuid.UUID  `json:"scan_id"`
 	Statistics Statistics `json:"statistics"`
+	Url        string     `json:"url,omitempty"`
 }
 
 type reportResults struct {
@@ -41,12 +44,14 @@ func println(msg string) {
 	fmt.Fprintln(output, msg)
 }
 
-func PrintOutputToFile(data []checkmodels.CheckRunResult, outputFilePath string) {
+func PrintOutputToFile(data []checkmodels.CheckRunResult, outputFilePath string, repositoryUrl string) {
 	reportRes, statistics := getPrintFormat(data)
 
 	// Populate the report metadata.
 	reportMetadata := reportMetadata{
 		Date:       time.Now().Format(time.RFC3339),
+		ScanID:     uuid.New(),
+		Url:        repositoryUrl,
 		Statistics: statistics,
 	}
 

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -23,10 +23,10 @@ func init() {
 	table.SetStyle(simpletable.StyleCompactLite)
 }
 
-func PrintFindings(results []checkmodels.CheckRunResult, outputFilePath string, isQuiet bool) {
+func PrintFindings(results []checkmodels.CheckRunResult, outputFilePath string, isQuiet bool, repositoryUrl string) {
 	sortResuls(results)
 	if outputFilePath != "" {
-		PrintOutputToFile(results, outputFilePath)
+		PrintOutputToFile(results, outputFilePath, repositoryUrl)
 	}
 	if !isQuiet {
 		s := NewStatistics()


### PR DESCRIPTION
This patch adds 2 identifiers to the report metadata section:
- a scan id, which which allows to identify a specific scan run
- a URL to ensure we know where the report was generated from

The main use case behind this patch is to be able to use the reports
without having to add extra context. For now we agreed on a convention
to name the report file as `{owner}-{repo}-{timestamp}.json`, but this
information gets lost when the content of the repost is simply shared
via email or pastebin.
