### PR TITLE
remove space in docs to resize bash views in git

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -65,6 +65,6 @@ docker pull aquasec/chain-bench:latest
 
 Example:
 
-    ``` bash
-    docker run --rm aquasec/chain-bench:latest scan --repository-url <REPOSITORY_URL> --access-token <TOKEN>
-    ```
+  ```bash
+  docker run --rm aquasec/chain-bench:latest scan --repository-url <REPOSITORY_URL> --access-token <TOKEN>
+  ```


### PR DESCRIPTION
## Description

I removed a space in the command display which allows to run `chain-bench` with docker.

Before :

        ``` bash
          docker run --rm aquasec/chain-bench:latest scan --repository-url <REPOSITORY_URL> --access-token <TOKEN>
        ```

After:

      ```bash
        docker run --rm aquasec/chain-bench:latest scan --repository-url <REPOSITORY_URL> --access-token <TOKEN>
      ```