### PR TITLE
Add support for self-hosted SCM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 
 .DS_Store
 /chain-bench
+/results.json

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Get Chain-bench via your favorite installation method. See [installation] sectio
 chain-bench scan --repository-url <REPOSITORY_URL> --access-token <TOKEN> -o <OUTPUT_PATH>
 ```
 
+### Using Self-hosted or Dedicated SCM Platforms (with custom domains)
+
+```bash
+chain-bench scan --repository-url <REPOSITORY_URL> --scm-platform <SCM_PLATFORM> --access-token <TOKEN> -o <OUTPUT_PATH>
+```
+
+Supported options for `scm-platform` are `"github"` and `"gitlab"` (beta)
+
 ### Using docker
 
 ```bash
@@ -155,7 +163,7 @@ chain-bench-scanning:
     name: docker.io/aquasec/chain-bench
     entrypoint: [""]
   script:
-    - chain-bench scan --repository-url $CI_PROJECT_URL --access-token $CHAIN_BENCH_TOKEN --scm gitlab -o results.json --template @/templates/gitlab_security_scanner.tpl
+    - chain-bench scan --repository-url $CI_PROJECT_URL --access-token $CHAIN_BENCH_TOKEN --scm-platform gitlab -o results.json --template @/templates/gitlab_security_scanner.tpl
   artifacts:
     reports:
       container_scanning: results.json

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ chain-bench-scanning:
     name: docker.io/aquasec/chain-bench
     entrypoint: [""]
   script:
-    - chain-bench scan --repository-url $CI_PROJECT_URL --access-token $CHAIN_BENCH_TOKEN -o results.json --template @/templates/gitlab_security_scanner.tpl
+    - chain-bench scan --repository-url $CI_PROJECT_URL --access-token $CHAIN_BENCH_TOKEN --scm gitlab -o results.json --template @/templates/gitlab_security_scanner.tpl
   artifacts:
     reports:
       container_scanning: results.json

--- a/internal/commands/flags.go
+++ b/internal/commands/flags.go
@@ -52,10 +52,10 @@ var (
 	accessTokenFlagName  = "access-token"
 	accessTokenShortFlag = "t"
 
-	// scm hosting the repository
-	scm          string
-	scmFlagName  = "scm"
-	scmShortFlag = "s"
+	// SCM platform for self-hosted/dedicated environments
+	scmPlatform          string
+	scmPlatformFlagName  = "scm-platform"
+	scmPlatformShortFlag = "s"
 
 	// branch the branch name to scan
 	branch          string

--- a/internal/commands/flags.go
+++ b/internal/commands/flags.go
@@ -47,10 +47,15 @@ var (
 	repositoryUrlFlagName  = "repository-url"
 	repositoryUrlShortFlag = "r"
 
-	// repositoryUrl the path to the repository to scan
+	// accessToken the access token to use for the repository
 	accessToken          string
 	accessTokenFlagName  = "access-token"
 	accessTokenShortFlag = "t"
+
+	// scm hosting the repository
+	scm          string
+	scmFlagName  = "scm"
+	scmShortFlag = "s"
 
 	// branch the branch name to scan
 	branch          string

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -19,7 +19,8 @@ func NewScanCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			start := time.Now()
 			logger.Infof("%v	Fetch Starting", emoji.TriangularFlag)
-			assetsData, supportedChecks, err := clients.FetchClientData(accessToken, repositoryUrl, scm, branch)
+
+			assetsData, supportedChecks, err := clients.FetchClientData(accessToken, repositoryUrl, scmPlatform, branch)
 			if err != nil {
 				logger.Error(err, "Failed to fetch client data")
 				return err
@@ -46,13 +47,13 @@ func NewScanCommand() *cobra.Command {
 		accessTokenFlagName, accessTokenShortFlag, "",
 		"the access token to use for the repository")
 
-	scanCommand.PersistentFlags().StringVarP(&scm,
-		scmFlagName, scmShortFlag, "github",
-		"the SCM to use for the repository")
+	scanCommand.PersistentFlags().StringVarP(&scmPlatform,
+		scmPlatformFlagName, scmPlatformShortFlag, "",
+		"the SCM platform for self-hosted/dedicated environments (options: 'github', 'gitlab')")
 
 	scanCommand.PersistentFlags().StringVarP(&branch,
 		branchFlagName, branchShortFlag, "",
-		"the branch to scan branch protection for")
+		"the branch to scan for branch protection")
 
 	return scanCommand
 }

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -19,7 +19,7 @@ func NewScanCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			start := time.Now()
 			logger.Infof("%v	Fetch Starting", emoji.TriangularFlag)
-			assetsData, supportedChecks, err := clients.FetchClientData(accessToken, repositoryUrl, branch)
+			assetsData, supportedChecks, err := clients.FetchClientData(accessToken, repositoryUrl, scm, branch)
 			if err != nil {
 				logger.Error(err, "Failed to fetch client data")
 				return err
@@ -45,6 +45,10 @@ func NewScanCommand() *cobra.Command {
 	scanCommand.PersistentFlags().StringVarP(&accessToken,
 		accessTokenFlagName, accessTokenShortFlag, "",
 		"the access token to use for the repository")
+
+	scanCommand.PersistentFlags().StringVarP(&scm,
+		scmFlagName, scmShortFlag, "github",
+		"the SCM to use for the repository")
 
 	scanCommand.PersistentFlags().StringVarP(&branch,
 		branchFlagName, branchShortFlag, "",

--- a/internal/scm-clients/adapter/adapter.go
+++ b/internal/scm-clients/adapter/adapter.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ClientAdapter interface {
-	Init(client *http.Client, token string) error
+	Init(client *http.Client, token string, host string) error
 	ListSupportedChecksIDs() ([]string, error)
 	GetRepository(owner, repo, branchName string) (*models.Repository, error)
 	ListRepositoryBranches(owner, repo string) ([]*models.Branch, error)

--- a/internal/scm-clients/clients/clients.go
+++ b/internal/scm-clients/clients/clients.go
@@ -18,17 +18,27 @@ import (
 )
 
 const (
-	GithubEndpoint = "github"
-	GitlabEndpoint = "gitlab"
+	GithubEndpoint = "github.com"
+	GitlabEndpoint = "gitlab.com"
+
+	GithubPlatform = "github"
+	GitlabPlatform = "gitlab"
 )
 
-func FetchClientData(accessToken string, repoUrl string, scm string, branch string) (*checkmodels.AssetsData, []string, error) {
+func FetchClientData(accessToken string, repoUrl string, scmPlatform string, branch string) (*checkmodels.AssetsData, []string, error) {
 	host, orgName, repoName, err := getRepoInfo(repoUrl)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	adapter, err := getClientAdapter(scm, accessToken, host)
+	switch host {
+	case GithubEndpoint:
+		scmPlatform = GithubPlatform
+	case GitlabPlatform:
+		scmPlatform = GitlabPlatform
+	}
+
+	adapter, err := getClientAdapter(scmPlatform, accessToken, host)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -94,16 +104,16 @@ func getRepoInfo(repoFullUrl string) (string, string, string, error) {
 	return u.Host, trimedNamespace, repo, nil
 }
 
-func getClientAdapter(scmName string, accessToken string, host string) (adapter.ClientAdapter, error) {
+func getClientAdapter(scmPlatform string, accessToken string, host string) (adapter.ClientAdapter, error) {
 	var err error
 	var adapter adapter.ClientAdapter
 	httpClient := utils.GetHttpClient(accessToken)
 
-	switch scmName {
-	case GithubEndpoint:
+	switch scmPlatform {
+	case GithubPlatform:
 		err = github.Adapter.Init(httpClient, accessToken, host)
 		adapter = &github.Adapter
-	case GitlabEndpoint:
+	case GitlabPlatform:
 		err = gitlab.Adapter.Init(httpClient, accessToken, host)
 		adapter = &gitlab.Adapter
 	default:

--- a/internal/scm-clients/clients/clients.go
+++ b/internal/scm-clients/clients/clients.go
@@ -73,10 +73,10 @@ func FetchClientData(accessToken string, repoUrl string, branch string) (*checkm
 	}, checksIds, nil
 }
 
-func getRepoInfo(repoUrl string) (scm string, org string, repo string, err error) {
-	u, err := url.Parse(repoUrl)
+func getRepoInfo(repoFullUrl string) (string, string, string, error) {
+	u, err := url.Parse(repoFullUrl)
 	if err != nil || u.Scheme == "" {
-		logger.Errorf(err, "error in parsing repoUrl %s", repoUrl)
+		logger.Errorf(err, "error in parsing repoUrl %s", repoFullUrl)
 		if err == nil {
 			err = errors.New("error in parsing the host")
 		}
@@ -85,9 +85,13 @@ func getRepoInfo(repoUrl string) (scm string, org string, repo string, err error
 
 	path := strings.Split(u.EscapedPath(), "/")
 	if len(path) < 3 {
-		return "", "", "", fmt.Errorf("missing org/repo in the repository url: %s", repoUrl)
+		return "", "", "", fmt.Errorf("missing org/repo in the repository url: %s", repoFullUrl)
 	}
-	return u.Host, path[1], path[2], nil
+	repo := path[len(path) - 1]
+	namespace := strings.Split(u.Path, repo)[0]
+	trimedNamespace := namespace[1:(len(namespace) - 1)]
+
+	return u.Host, trimedNamespace, repo, nil
 }
 
 func getClientAdapter(scmName string, accessToken string) (adapter.ClientAdapter, error) {

--- a/internal/scm-clients/clients/clients_test.go
+++ b/internal/scm-clients/clients/clients_test.go
@@ -1,0 +1,68 @@
+package clients
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type RepoInfo struct {
+	BaseUrl   string
+	Namespace string
+	Project   string
+}
+
+func TestGetRepoInfo(t *testing.T) {
+
+	tests := []struct {
+		Name        string
+		RepoUrl     string
+		ExpectedErr error
+		Expected    RepoInfo
+	}{{
+		Name:        "missing url schema",
+		RepoUrl:     "gitlab.com/rootgroup/subgroup/secondsubgroup/test",
+		ExpectedErr: fmt.Errorf("error in parsing the host"),
+		Expected:    RepoInfo{BaseUrl: "", Namespace: "", Project: ""},
+	}, {
+		Name:        "invalid url",
+		RepoUrl:     "https://gitlab?com/rootgroup/subgroup/secondsubgroup/test",
+		ExpectedErr: fmt.Errorf("missing org/repo in the repository url: %s", "https://gitlab?com/rootgroup/subgroup/secondsubgroup/test"),
+		Expected:    RepoInfo{BaseUrl: "", Namespace: "", Project: ""},
+	}, {
+		Name:        "github repo",
+		RepoUrl:     "https://github.com/aquasecurity/chain-bench",
+		ExpectedErr: nil,
+		Expected:    RepoInfo{BaseUrl: "github.com", Namespace: "aquasecurity", Project: "chain-bench"},
+	}, {
+		Name:        "gitlab project under root group",
+		RepoUrl:     "https://gitlab.com/rootgroup/test",
+		ExpectedErr: nil,
+		Expected:    RepoInfo{BaseUrl: "gitlab.com", Namespace: "rootgroup", Project: "test"},
+	}, {
+		Name:        "gitlab project under sub group",
+		RepoUrl:     "https://gitlab.com/rootgroup/subgroup/secondsubgroup/test",
+		ExpectedErr: nil,
+		Expected:    RepoInfo{BaseUrl: "gitlab.com", Namespace: "rootgroup/subgroup/secondsubgroup", Project: "test"},
+	}}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+
+			baseUrl, namespace, project, err := getRepoInfo(test.RepoUrl)
+
+			if test.ExpectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, test.ExpectedErr.Error())
+			}
+			assert.Equal(t, test.Expected.BaseUrl, baseUrl)
+			assert.Equal(t, test.Expected.Namespace, namespace)
+			assert.Equal(t, test.Expected.Project, project)
+		})
+	}
+
+}

--- a/internal/scm-clients/github/adapter.go
+++ b/internal/scm-clients/github/adapter.go
@@ -23,8 +23,8 @@ type ClientAdapterImpl struct {
 }
 
 // Init implements clients.ClientAdapter
-func (*ClientAdapterImpl) Init(client *http.Client, token string) error {
-	ghClient, err := InitClient(client, token)
+func (*ClientAdapterImpl) Init(client *http.Client, token string, host string) error {
+	ghClient, err := InitClient(client, token, host)
 	Adapter = ClientAdapterImpl{client: ghClient}
 	return err
 }

--- a/internal/scm-clients/github/client_mocks.go
+++ b/internal/scm-clients/github/client_mocks.go
@@ -12,7 +12,7 @@ func MockGetRepo(repo *github.Repository) *GithubClient {
 			*repo,
 		),
 	)
-	gc, _ := InitClient(mockedHTTPClient,"")
+	gc, _ := InitClient(mockedHTTPClient, "", "github.com")
 	return &gc
 }
 
@@ -23,7 +23,7 @@ func MockGetBranchProtections(protection *github.Protection) *GithubClient {
 			*protection,
 		),
 	)
-	gc, _ := InitClient(mockedHTTPClient, "")
+	gc, _ := InitClient(mockedHTTPClient, "", "github.com")
 	return &gc
 }
 
@@ -34,7 +34,7 @@ func MockGetSignaturesOfProtectedBranch(signedCommits *github.SignaturesProtecte
 			*signedCommits,
 		),
 	)
-	gc, _ := InitClient(mockedHTTPClient, "")
+	gc, _ := InitClient(mockedHTTPClient, "", "github.com")
 	return &gc
 }
 
@@ -45,7 +45,7 @@ func MockGetOrganization(org *github.Organization) *GithubClient {
 			*org,
 		),
 	)
-	gc, _ := InitClient(mockedHTTPClient, "")
+	gc, _ := InitClient(mockedHTTPClient, "", "github.com")
 	return &gc
 }
 
@@ -56,7 +56,7 @@ func MockGetOrganizationMembers(users []*github.User) *GithubClient {
 			users,
 		),
 	)
-	gc, _ := InitClient(mockedHTTPClient, "")
+	gc, _ := InitClient(mockedHTTPClient, "", "github.com")
 	return &gc
 }
 
@@ -67,7 +67,7 @@ func MockGetWorkflows(workflows *github.Workflows) *GithubClient {
 			workflows,
 		),
 	)
-	gc, _ := InitClient(mockedHTTPClient, "")
+	gc, _ := InitClient(mockedHTTPClient, "", "github.com")
 	return &gc
 }
 
@@ -78,7 +78,7 @@ func MockGetContent(content *github.RepositoryContent) *GithubClient {
 			content,
 		),
 	)
-	gc, _ := InitClient(mockedHTTPClient, "")
+	gc, _ := InitClient(mockedHTTPClient, "", "github.com")
 	return &gc
 }
 
@@ -89,7 +89,7 @@ func MockGetOrganizationWebhooks(hooks []*github.Hook) *GithubClient {
 			hooks,
 		),
 	)
-	gc, _ := InitClient(mockedHTTPClient, "")
+	gc, _ := InitClient(mockedHTTPClient, "", "github.com")
 	return &gc
 }
 
@@ -100,7 +100,7 @@ func MockGetRepositoryWebhooks(hooks []*github.Hook) *GithubClient {
 			hooks,
 		),
 	)
-	gc, _ := InitClient(mockedHTTPClient, "")
+	gc, _ := InitClient(mockedHTTPClient, "", "github.com")
 	return &gc
 }
 
@@ -111,7 +111,7 @@ func MockListCommits(commits []*github.RepositoryCommit) *GithubClient {
 			commits,
 		),
 	)
-	gc, _ := InitClient(mockedHTTPClient, "")
+	gc, _ := InitClient(mockedHTTPClient, "", "github.com")
 	return &gc
 }
 
@@ -122,6 +122,6 @@ func MockListOrganizationPackages(packages []*github.Package) *GithubClient {
 			packages,
 		),
 	)
-	gc, _ := InitClient(mockedHTTPClient, "")
+	gc, _ := InitClient(mockedHTTPClient, "", "github.com")
 	return &gc
 }

--- a/internal/scm-clients/github/github.go
+++ b/internal/scm-clients/github/github.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/aquasecurity/chain-bench/internal/utils"
@@ -43,7 +44,13 @@ type GithubClientImpl struct {
 var _ GithubClient = (*GithubClientImpl)(nil) // Verify that *GithubClientImpl implements GithubClient.
 
 func InitClient(client *http.Client, token string, host string) (GithubClient, error) {
-	gc := github.NewClient(client)
+	var gc *github.Client
+	if host == "github.com" {
+		gc = github.NewClient(client)
+	} else {
+		gc, _ = github.NewEnterpriseClient(fmt.Sprintf("https://%s/api/v3/", host), fmt.Sprintf("https://%s/api/uploads/", host), client)
+	}
+
 	Client = &GithubClientImpl{ctx: context.TODO(), client: gc}
 	return Client, nil
 }

--- a/internal/scm-clients/github/github.go
+++ b/internal/scm-clients/github/github.go
@@ -42,7 +42,7 @@ type GithubClientImpl struct {
 
 var _ GithubClient = (*GithubClientImpl)(nil) // Verify that *GithubClientImpl implements GithubClient.
 
-func InitClient(client *http.Client, token string) (GithubClient, error) {
+func InitClient(client *http.Client, token string, host string) (GithubClient, error) {
 	gc := github.NewClient(client)
 	Client = &GithubClientImpl{ctx: context.TODO(), client: gc}
 	return Client, nil
@@ -116,17 +116,17 @@ func (gca *GithubClientImpl) GetContent(owner, repo, filepath, ref string) (file
 	return gca.client.Repositories.GetContents(gca.ctx, owner, repo, filepath, &github.RepositoryContentGetOptions{Ref: ref})
 }
 
-//need admin:repo_hook->read:repo_hook
+// need admin:repo_hook->read:repo_hook
 func (gca *GithubClientImpl) ListRepositoryHooks(owner, repo string) (hooks []*github.Hook, resp *github.Response, err error) {
 	return gca.client.Repositories.ListHooks(gca.ctx, owner, repo, nil)
 }
 
-//need admin:org_hook
+// need admin:org_hook
 func (gca *GithubClientImpl) ListOrganizationHooks(owner string) (hooks []*github.Hook, resp *github.Response, err error) {
 	return gca.client.Organizations.ListHooks(gca.ctx, owner, nil)
 }
 
-//need read:packages
+// need read:packages
 func (gca *GithubClientImpl) ListOrganizationPackages(owner string, packageType string) ([]*github.Package, *github.Response, error) {
 	return gca.client.Organizations.ListPackages(gca.ctx, owner, &github.PackageListOptions{State: utils.GetPtr("active"), PackageType: &packageType})
 }

--- a/internal/scm-clients/gitlab/adapter.go
+++ b/internal/scm-clients/gitlab/adapter.go
@@ -19,8 +19,8 @@ type ClientAdapterImpl struct {
 	client GitlabClient
 }
 
-func (*ClientAdapterImpl) Init(client *http.Client, token string) error {
-	glClient, err := InitClient(client, token)
+func (*ClientAdapterImpl) Init(client *http.Client, token string, host string) error {
+	glClient, err := InitClient(client, token, host)
 	Adapter = ClientAdapterImpl{client: glClient}
 	return err
 }

--- a/internal/scm-clients/gitlab/gitlab.go
+++ b/internal/scm-clients/gitlab/gitlab.go
@@ -31,7 +31,12 @@ type GitlabClientImpl struct {
 var _ GitlabClient = (*GitlabClientImpl)(nil) // Verify that *GitlabClientImpl implements gitlabClient.
 
 func InitClient(client *http.Client, token string, host string) (GitlabClient, error) {
-	gc, _ := gitlab.NewClient(token, gitlab.WithHTTPClient(client), gitlab.WithBaseURL(fmt.Sprintf("https://%s/api/v4", host)))
+	var gc *gitlab.Client
+	if host == "gitlab.com" {
+		gc, _ = gitlab.NewClient(token, gitlab.WithHTTPClient(client))
+	} else {
+		gc, _ = gitlab.NewClient(token, gitlab.WithHTTPClient(client), gitlab.WithBaseURL(fmt.Sprintf("https://%s/api/v4", host)))
+	}
 	Client = &GitlabClientImpl{ctx: context.TODO(), client: gc}
 	return Client, nil
 }

--- a/internal/scm-clients/gitlab/gitlab.go
+++ b/internal/scm-clients/gitlab/gitlab.go
@@ -30,12 +30,11 @@ type GitlabClientImpl struct {
 
 var _ GitlabClient = (*GitlabClientImpl)(nil) // Verify that *GitlabClientImpl implements gitlabClient.
 
-func InitClient(client *http.Client, token string) (GitlabClient, error) {
-	gc, _ := gitlab.NewClient(token, gitlab.WithHTTPClient(client))
+func InitClient(client *http.Client, token string, host string) (GitlabClient, error) {
+	gc, _ := gitlab.NewClient(token, gitlab.WithHTTPClient(client), gitlab.WithBaseURL(fmt.Sprintf("https://%s/api/v4", host)))
 	Client = &GitlabClientImpl{ctx: context.TODO(), client: gc}
 	return Client, nil
 }
-
 func (gca *GitlabClientImpl) GetAuthorizedUser() (*gitlab.User, *gitlab.Response, error) {
 	return gca.client.Users.GetUser(1, gitlab.GetUsersOptions{})
 }

--- a/internal/scm-clients/gitlab/mapper.go
+++ b/internal/scm-clients/gitlab/mapper.go
@@ -46,7 +46,7 @@ func toRepository(repo *gitlab.Project, branches []*models.Branch, collaborators
 		r = &models.Repository{
 			ID:                   utils.GetPtr(int64(repo.ID)),
 			Owner:                &models.User{Type: utils.GetPtr("Organization")},
-			Name:                 &repo.Name,
+			Name:                 &repo.Path,
 			Description:          &repo.Description,
 			DefaultBranch:        &repo.DefaultBranch,
 			CreatedAt:            &utils.Timestamp{Time: utils.GetValue(repo.CreatedAt)},

--- a/internal/scm-clients/gitlab/mapper_test.go
+++ b/internal/scm-clients/gitlab/mapper_test.go
@@ -55,7 +55,7 @@ func TestToRepository(t *testing.T) {
 
 	actual := toRepository(
 		&gitlab.Project{
-			Name:  repoName,
+			Path:  repoName,
 			ID:    433,
 			Owner: &gitlab.User{},
 		},


### PR DESCRIPTION
## Description

This PR adds support for optionally specifying a SCM to support self-hosted environments. The change defaults to `github` for backwards compatibility but should support Gitlab or GitHub self-hosted/enterprise deployments on a custom domain.

### Before
`chain-bench scan --repository-url <REPOSITORY_URL> --access-token <TOKEN> -o <OUTPUT_PATH>`

### After

`chain-bench scan --repository-url <REPOSITORY_URL> --access-token <TOKEN> --scm-platform gitlab -o <OUTPUT_PATH>`

Without SCM, chain-bench will fallback to Github SaaS - `chain-bench scan --repository-url <REPOSITORY_URL> --access-token <TOKEN> -o <OUTPUT_PATH>`

Currently only tested on Gitlab but opening the PR early for discussion. The PR also includes a small fix for Gitlab querying protected branches where repo names don't match the escaped path.

## Related issues
- Closes #110

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/chain-bench/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've followed the [conventions](https://github.com/aquasecurity/chain-bench/blob/main/CONTRIBUTING.md#pull-requests) in the PR title.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [readme](https://github.com/aquasecurity/chain-bench/blob/main/README.md) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
