### PR TITLE
Fix issue with get repo info #130

### DIFF
--- a/internal/scm-clients/clients/clients.go
+++ b/internal/scm-clients/clients/clients.go
@@ -103,8 +103,8 @@ func getRepoInfo(repoFullUrl string) (string, string, string, error) {
 		return "", "", "", fmt.Errorf("missing org/repo in the repository url: %s", repoFullUrl)
 	}
 	repo := path[len(path)-1]
-	namespace := strings.Split(u.Path, repo)[0]
-	trimedNamespace := namespace[1:(len(namespace) - 1)]
+	namespace := strings.Join(path[:len(path)-1], "/")
+	trimedNamespace := strings.TrimLeft(namespace, "/")
 
 	return u.Host, trimedNamespace, repo, nil
 }

--- a/internal/scm-clients/clients/clients_test.go
+++ b/internal/scm-clients/clients/clients_test.go
@@ -54,7 +54,7 @@ func TestGetRepoInfo(t *testing.T) {
 		Name:        "github project under sub org with same name as repo",
 		RepoUrl:     "https://github.com/codekuu/suborg/secondsuborg/secondsuborg",
 		ExpectedErr: nil,
-		Expected:    RepoInfo{BaseUrl: "gitlab.com", Namespace: "codekuu/suborg/secondsuborg", Project: "secondsuborg"},
+		Expected:    RepoInfo{BaseUrl: "github.com", Namespace: "codekuu/suborg/secondsuborg", Project: "secondsuborg"},
 	}}
 
 	for _, test := range tests {

--- a/internal/scm-clients/clients/clients_test.go
+++ b/internal/scm-clients/clients/clients_test.go
@@ -52,7 +52,7 @@ func TestGetRepoInfo(t *testing.T) {
 		Expected:    RepoInfo{BaseUrl: "gitlab.com", Namespace: "rootgroup/subgroup/secondsubgroup", Project: "secondsubgroup"},
 	}, {
 		Name:        "github project under sub org with same name as repo",
-		RepoUrl:     "https://github.com/codekuu/suborg/secondsuborg/secondsuborg",
+		RepoUrl:     "https://gitlab.com/codekuu/suborg/secondsuborg/secondsuborg",
 		ExpectedErr: nil,
 		Expected:    RepoInfo{BaseUrl: "gitlab.com", Namespace: "codekuu/suborg/secondsuborg", Project: "secondsuborg"},
 	}}

--- a/internal/scm-clients/clients/clients_test.go
+++ b/internal/scm-clients/clients/clients_test.go
@@ -54,7 +54,7 @@ func TestGetRepoInfo(t *testing.T) {
 		Name:        "github project under sub org with same name as repo",
 		RepoUrl:     "https://github.com/codekuu/suborg/secondsuborg/secondsuborg",
 		ExpectedErr: nil,
-		Expected:    RepoInfo{BaseUrl: "github.com", Namespace: "codekuu/suborg/secondsuborg", Project: "secondsuborg"},
+		Expected:    RepoInfo{BaseUrl: "gitlab.com", Namespace: "codekuu/suborg/secondsuborg", Project: "secondsuborg"},
 	}}
 
 	for _, test := range tests {

--- a/internal/scm-clients/clients/clients_test.go
+++ b/internal/scm-clients/clients/clients_test.go
@@ -51,7 +51,7 @@ func TestGetRepoInfo(t *testing.T) {
 		ExpectedErr: nil,
 		Expected:    RepoInfo{BaseUrl: "gitlab.com", Namespace: "rootgroup/subgroup/secondsubgroup", Project: "secondsubgroup"},
 	}, {
-		Name:        "github project under sub org with same name as repo",
+		Name:        "gitlab project under sub org with same name as repo",
 		RepoUrl:     "https://gitlab.com/codekuu/suborg/secondsuborg/secondsuborg",
 		ExpectedErr: nil,
 		Expected:    RepoInfo{BaseUrl: "gitlab.com", Namespace: "codekuu/suborg/secondsuborg", Project: "secondsuborg"},

--- a/internal/scm-clients/clients/clients_test.go
+++ b/internal/scm-clients/clients/clients_test.go
@@ -45,6 +45,16 @@ func TestGetRepoInfo(t *testing.T) {
 		RepoUrl:     "https://gitlab.com/rootgroup/subgroup/secondsubgroup/test",
 		ExpectedErr: nil,
 		Expected:    RepoInfo{BaseUrl: "gitlab.com", Namespace: "rootgroup/subgroup/secondsubgroup", Project: "test"},
+	}, {
+		Name:        "gitlab project under sub group with same name as repo",
+		RepoUrl:     "https://gitlab.com/rootgroup/subgroup/secondsubgroup/secondsubgroup",
+		ExpectedErr: nil,
+		Expected:    RepoInfo{BaseUrl: "gitlab.com", Namespace: "rootgroup/subgroup/secondsubgroup", Project: "secondsubgroup"},
+	}, {
+		Name:        "github project under sub org with same name as repo",
+		RepoUrl:     "https://github.com/codekuu/suborg/secondsuborg/secondsuborg",
+		ExpectedErr: nil,
+		Expected:    RepoInfo{BaseUrl: "gitlab.com", Namespace: "codekuu/suborg/secondsuborg", Project: "secondsuborg"},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description
Issue when the sub group has the same name as the repository.
The getRepoInfo function does not parse it out correctly.

This fixes this issue.

Example url: `https://my-gitlab-instance.com/top-group/sub-group/repo-name/repo-name`
getRepoInfo returned before:
```
host: my-gitlab-instance.com
namespace: top-group/sub-group
repo: repo-name
err: %!s(<nil>)
```

it now returns:
```
host: my-gitlab-instance.com
namespace: top-group/sub-group/repo-name
repo: repo-name
err: %!s(<nil>)
```



## Related issues
- Close #130
Might close:
- Close #80 

## Checklist
- [X] I've read the [guidelines for contributing](https://github.com/aquasecurity/chain-bench/blob/main/CONTRIBUTING.md) to this repository.
- [X] I've followed the [conventions](https://github.com/aquasecurity/chain-bench/blob/main/CONTRIBUTING.md#pull-requests) in the PR title.
- [X] I've added tests that prove my fix is effective or that my feature works.
- [N/A] I've updated the [readme](https://github.com/aquasecurity/chain-bench/blob/main/README.md) with the relevant information (if needed).
- [N/A] I've added usage information (if the PR introduces new options)
- [X] I've included a "before" and "after" example to the description (if the PR is a user interface change).
